### PR TITLE
Fix document not rendering if passed in `RichTextViewController.init`

### DIFF
--- a/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
+++ b/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
@@ -110,6 +110,8 @@ open class RichTextViewController: UIViewController, NSLayoutManagerDelegate {
         setupTextView()
 
         textContainer.size.height = .greatestFiniteMagnitude
+
+        renderDocumentIfNeeded()
     }
 
     private func setupTextView() {


### PR DESCRIPTION
`RichTextViewController` won't render a document if it's passed in the view controller's initializer - as opposed to setting it afterwards like in the example app.

This is because `renderDocumentIfNeeded()` is only called in `richTextDocument.didSet` but `willSet` and `didSet` are not called when a property is set on `init`.

To fix the issue, I basically added a call to `renderDocumentIfNeeded()` at the end of the view load.