### PR TITLE
chore: fix hyperlink crash when it contains special characters like s…

### DIFF
--- a/Sources/RichTextRenderer/NodeRenderers/Hyperlink/HyperlinkRenderer.swift
+++ b/Sources/RichTextRenderer/NodeRenderers/Hyperlink/HyperlinkRenderer.swift
@@ -26,9 +26,12 @@ open class HyperlinkRenderer: NodeRendering {
             result.append(child)
         }
 
+        // Prevent crashes for links with spaces or other special characters
+        let encodedURI = node.data.uri.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? node.data.uri
+        
         result.addAttributes(
             [
-                .link: node.data.uri,
+                .link: encodedURI,
             ],
             range: result.fullRange
         )


### PR DESCRIPTION
Fixes a crash of the SDK, when the HyperLink object comes back from API containing some special symbols like spaces e.g. %20 and previous implementation could not handle that